### PR TITLE
Fix #7: Allow ShareLink::create() to accept array resources

### DIFF
--- a/tests/Feature/ResourceModelPreviewTest.php
+++ b/tests/Feature/ResourceModelPreviewTest.php
@@ -2,19 +2,16 @@
 
 declare(strict_types=1);
 
-use Grazulex\ShareLink\Models\ShareLink;
+use Grazulex\ShareLink\Facades\ShareLink;
 
 it('returns JSON model preview fallback in debug for model targets', function (): void {
     config()->set('app.debug', true);
 
     $link = ShareLink::create([
-        'resource' => [
-            'type' => 'model',
-            'class' => 'App\\Models\\Post',
-            'id' => 123,
-        ],
-        'token' => 'md-'.bin2hex(random_bytes(3)),
-    ]);
+        'type' => 'model',
+        'class' => 'App\\Models\\Post',
+        'id' => 123,
+    ])->generate();
 
     $this->get('/share/'.$link->token)
         ->assertStatus(200)

--- a/tests/Feature/ResourceRouteTargetTest.php
+++ b/tests/Feature/ResourceRouteTargetTest.php
@@ -2,20 +2,17 @@
 
 declare(strict_types=1);
 
-use Grazulex\ShareLink\Models\ShareLink;
+use Grazulex\ShareLink\Facades\ShareLink;
 use Illuminate\Support\Facades\Route;
 
 it('redirects to a named route when resource type is route', function (): void {
     Route::get('/hello/{name}', fn (string $name) => 'Hello '.$name)->name('hello');
 
     $link = ShareLink::create([
-        'resource' => [
-            'type' => 'route',
-            'name' => 'hello',
-            'params' => ['name' => 'World'],
-        ],
-        'token' => 'rt-'.bin2hex(random_bytes(3)),
-    ]);
+        'type' => 'route',
+        'name' => 'hello',
+        'params' => ['name' => 'World'],
+    ])->generate();
 
     $this->get('/share/'.$link->token)
         ->assertRedirect(route('hello', ['name' => 'World']));

--- a/tests/Unit/ShareLinkManagerTest.php
+++ b/tests/Unit/ShareLinkManagerTest.php
@@ -20,3 +20,87 @@ it('generates a URL and applies password hashing when provided', function (): vo
         ->toContain('/share/')
         ->and($model->password)->not->toBe('secret');
 });
+
+it('accepts array resource for route type', function (): void {
+    $manager = new ShareLinkManager();
+
+    $model = $manager->create([
+        'type' => 'route',
+        'name' => 'user.profile',
+        'params' => ['id' => 123],
+    ])->generate();
+
+    expect($model)->toBeInstanceOf(ShareLink::class)
+        ->and($model->resource)->toBeArray()
+        ->and($model->resource['type'])->toBe('route')
+        ->and($model->resource['name'])->toBe('user.profile')
+        ->and($model->resource['params'])->toBe(['id' => 123]);
+});
+
+it('accepts array resource for model type', function (): void {
+    $manager = new ShareLinkManager();
+
+    $model = $manager->create([
+        'type' => 'model',
+        'class' => 'App\\Models\\Post',
+        'id' => 456,
+    ])->generate();
+
+    expect($model)->toBeInstanceOf(ShareLink::class)
+        ->and($model->resource)->toBeArray()
+        ->and($model->resource['type'])->toBe('model')
+        ->and($model->resource['class'])->toBe('App\\Models\\Post')
+        ->and($model->resource['id'])->toBe(456);
+});
+
+it('throws exception when array resource is missing type', function (): void {
+    $manager = new ShareLinkManager();
+
+    $manager->create([
+        'name' => 'route.name',
+    ]);
+})->throws(InvalidArgumentException::class, 'Array resource must have a "type" key.');
+
+it('throws exception when route resource is missing name', function (): void {
+    $manager = new ShareLinkManager();
+
+    $manager->create([
+        'type' => 'route',
+    ]);
+})->throws(InvalidArgumentException::class, 'Route resource must have a non-empty "name" key.');
+
+it('throws exception when route resource has invalid params', function (): void {
+    $manager = new ShareLinkManager();
+
+    $manager->create([
+        'type' => 'route',
+        'name' => 'test',
+        'params' => 'not-an-array',
+    ]);
+})->throws(InvalidArgumentException::class, 'Route resource "params" must be an array.');
+
+it('throws exception when model resource is missing class', function (): void {
+    $manager = new ShareLinkManager();
+
+    $manager->create([
+        'type' => 'model',
+        'id' => 123,
+    ]);
+})->throws(InvalidArgumentException::class, 'Model resource must have a non-empty "class" key.');
+
+it('throws exception when model resource is missing id', function (): void {
+    $manager = new ShareLinkManager();
+
+    $manager->create([
+        'type' => 'model',
+        'class' => 'App\\Models\\Post',
+    ]);
+})->throws(InvalidArgumentException::class, 'Model resource must have a non-null "id" key.');
+
+it('throws exception when array resource has invalid type', function (): void {
+    $manager = new ShareLinkManager();
+
+    $manager->create([
+        'type' => 'invalid',
+    ]);
+})->throws(InvalidArgumentException::class, 'Array resource type must be "route" or "model". Got: invalid');


### PR DESCRIPTION
Updated ShareLinkManager::create() and PendingShareLink to accept string|array parameters, enabling route and model sharing via facade.

Changes:
- Modified method signatures to accept string|array
- Added validateArrayResource() with comprehensive validation
- Added 8 unit tests for array resource validation
- Updated feature tests to use facade instead of direct model creation

All tests pass (49/49), PHPStan level 5 clean, code style verified.

## Description

<!-- Provide a brief description of the changes made in this PR -->

## Related Issue

<!-- If this PR addresses an issue, please link it here -->
Closes #

## Type of Change

<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

<!-- List the specific changes made in this PR -->
- 
- 
- 

## Testing

<!-- Describe how you tested your changes -->
- [ ] Tests added/updated for the changes
- [ ] All existing tests pass
- [ ] New tests pass
- [ ] Manual testing performed

## Code Quality

<!-- Ensure code quality standards are met -->
- [ ] Code follows the project's style guidelines
- [ ] Self-review of code performed
- [ ] Code is properly documented
- [ ] No unnecessary debug code or comments left

## Screenshots (if applicable)

<!-- Add screenshots if your changes affect the UI or visual output -->

## Additional Notes

<!-- Add any additional notes, considerations, or context for reviewers -->

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guide
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes